### PR TITLE
switch from static to dynamic MKL linking on Windows using mkl_rt

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,6 +10,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+mkl:
+- '2024'
 target_platform:
 - win-64
 zlib:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  BLAS_LIB=( --with-blas-lib='${LIBRARY_PREFIX}/lib/mkl_intel_ilp64.lib ${LIBRARY_PREFIX}/lib/mkl_sequential.lib ${LIBRARY_PREFIX}/lib/mkl_core.lib' )
+  BLAS_LIB=( --with-blas-lib='-L${PREFIX}/lib -lmkl_rt' )
   LAPACK_LIB=( --with-lapack-lib='' )
   EXTRA_FLAGS=( --enable-msvc=MD )
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  BLAS_LIB=( --with-blas-lib='-L${PREFIX}/lib -lmkl_rt' )
+  BLAS_LIB=( --with-blas-lib='-L${LIBRARY_PREFIX}/lib -lmkl_rt' )
   LAPACK_LIB=( --with-lapack-lib='' )
   EXTRA_FLAGS=( --enable-msvc=MD )
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  BLAS_LIB=( --with-blas-lib='-L${LIBRARY_PREFIX}/lib -lmkl_rt' )
+  BLAS_LIB=( --with-blas-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib' )
   LAPACK_LIB=( --with-lapack-lib='' )
   EXTRA_FLAGS=( --enable-msvc=MD )
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
   number: 3
   run_exports:
     - {{ pin_subpackage(name, min_pin='x.x', max_pin='x.x') }}
-    - mkl-static  # [win]
 
 requirements:
   build:
@@ -38,7 +37,7 @@ requirements:
     - libcblas  # [unix]
     - liblapack  # [unix]
     - liblapacke  # [unix]
-    - mkl-static  # [win]
+    - mkl  # [win]
     - zlib
     - bzip2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Patch-for-downstream.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, min_pin='x.x', max_pin='x.x') }}
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The current static linkage causes unresolved external symbols and dependency propagation issues in downstream projects using `coin-or-utils`, including:

- `MKLMPI_Get_wrappers` missing symbol errors
- `mkl_cdft_...` unresolved symbols
- implicit dependency on `libdecimal.lib` and others that must be manually added downstream

@davide-f feel free to add/comment