### PR TITLE
Fix run_export

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,7 +10,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-mkl:
+mkl_devel:
 - '2024'
 target_platform:
 - win-64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Patch-for-downstream.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage(name, min_pin='x.x', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - libcblas  # [unix]
     - liblapack  # [unix]
     - liblapacke  # [unix]
-    - mkl  # [win]
+    - mkl-devel  # [win]
     - zlib
     - bzip2
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

coin-or-clp fails. Checking the builds being installed of mkl; the build of osi and utils do have different hash. without the run_export, conda does not understand that to use coin-or-utils there is the need to have mkl and have mkl with a specific version/build

By using mkl-devel, the run_export is added automatically, see https://github.com/conda-forge/intel_repack-feedstock/blob/28b063f8cde0c4ab139ac56d8eb0763ac44bd021/recipe/meta.yaml#L671
